### PR TITLE
Create in-memory storage and implement GET and SET commands

### DIFF
--- a/benches/kv_benchmark.rs
+++ b/benches/kv_benchmark.rs
@@ -1,8 +1,7 @@
 use std::io::Cursor;
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-
 use anode_kv::codec::decode;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 fn kv_benchmark(c: &mut Criterion) {
     c.bench_function("parse_string", |b| {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+group_imports = "StdExternalCrate"

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -2,6 +2,8 @@ use std::io::{Read, Write};
 
 use thiserror::Error;
 
+use crate::types::Bytes;
+
 pub const CRLF: &str = "\r\n";
 
 #[derive(Clone, Debug, PartialEq)]
@@ -11,6 +13,12 @@ pub enum Token {
     Error(String),
     BulkString(Option<Vec<u8>>),
     Array(i64),
+}
+
+impl From<Bytes> for Token {
+    fn from(b: Bytes) -> Self {
+        Token::BulkString(Some(b.0))
+    }
 }
 
 #[derive(Error, Debug)]
@@ -201,8 +209,9 @@ fn read_bulk_string<T: Read>(s: &mut T, length: usize) -> Result<Vec<u8>, ReadEr
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test::Bencher;
+
+    use super::*;
 
     #[test]
     fn decodes_integers() {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -6,7 +6,7 @@ use crate::types::Bytes;
 
 pub const CRLF: &str = "\r\n";
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Token {
     SimpleString(String),
     Integer(i64),

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -342,7 +342,7 @@ mod tests {
             let encoded = encode(&mut buf, &decoded.unwrap());
 
             assert!(encoded.is_ok());
-            assert_eq!(message.bytes().collect::<Vec<u8>>(), buf); // TODO: fix
+            assert_eq!(message.bytes().collect::<Vec<u8>>(), buf);
         }
     }
 

--- a/src/command/command.rs
+++ b/src/command/command.rs
@@ -48,8 +48,8 @@ impl Command {
         };
         log::info!("length: {}", length);
 
-        match cmd {
-            _ if cmd == "ECHO" => {
+        match cmd.as_str() {
+            "ECHO" => {
                 if length != 2 {
                     return Err(CommandError::Malformed);
                 }
@@ -60,13 +60,13 @@ impl Command {
                 };
                 Ok((Command::Echo(reply_token), 3))
             }
-            _ if cmd == "COMMAND" => {
+            "COMMAND" => {
                 if length != 1 {
                     return Err(CommandError::Malformed);
                 }
                 Ok((Command::Command, 2))
             }
-            _ if cmd == "GET" => {
+            "GET" => {
                 if length != 2 {
                     return Err(CommandError::Malformed);
                 }
@@ -78,7 +78,7 @@ impl Command {
 
                 Ok((Command::Get(key), 3))
             }
-            _ if cmd == "SET" => {
+            "SET" => {
                 if length != 3 {
                     return Err(CommandError::Malformed);
                 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -75,10 +75,13 @@ fn error_response(msg: String) -> Vec<Token> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn it_echoes() {
-        let cp = CommandProcessor::new(Context::dummy());
+        let (tx, _rx) = mpsc::channel(1);
+        let context = Context::new(tx);
+        let cp = CommandProcessor::new(context);
 
         let cmd = Command::Echo(vec![0u8, 1u8, 2u8]);
         let expected = vec![Token::BulkString(Some(vec![0u8, 1u8, 2u8]))];

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -6,8 +6,8 @@ use crate::codec::Token;
 use crate::server::Context;
 use crate::storage::StorageCommand;
 
-mod command;
-pub use command::{Command, CommandError};
+mod types;
+pub use types::{Command, CommandError};
 
 /// CommandProcessor is responsible for taking a group of tokens, executing them,
 /// and returning the result.
@@ -53,7 +53,7 @@ impl CommandProcessor {
                     .send_timeout((cmd, tx), Duration::from_millis(1_000))
                     .await;
 
-                if let Err(_) = res {
+                if res.is_err() {
                     return "timeout while sending to storage".into();
                 }
 
@@ -73,7 +73,7 @@ impl CommandProcessor {
                     .send_timeout((cmd, tx), Duration::from_millis(1_000))
                     .await;
 
-                if let Err(_) = res {
+                if res.is_err() {
                     return "timeout while sending to storage".into();
                 }
 
@@ -93,6 +93,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
+    use crate::types::Bytes;
 
     #[tokio::test]
     async fn it_echoes() {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,32 +1,90 @@
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+
 use crate::codec::Token;
+use crate::server::Context;
+use crate::storage::StorageCommand;
 
 mod command;
 pub use command::{Command, CommandError};
 
 /// CommandProcessor is responsible for taking a group of tokens, executing them,
 /// and returning the result.
-pub struct CommandProcessor {}
+pub struct CommandProcessor {
+    context: Context,
+}
 
 impl CommandProcessor {
-    pub fn execute_command(&self, command: &Command) -> Vec<Token> {
+    pub fn new(context: Context) -> Self {
+        Self { context }
+    }
+
+    pub async fn execute_command(&self, command: &Command) -> Vec<Token> {
         match command {
             Command::Echo(t) => vec![Token::BulkString(Some(t.clone()))],
             Command::Command => vec![Token::BulkString(Some("ECHO".bytes().collect()))],
+            Command::Get(key) => {
+                let cmd = StorageCommand::Get(key.clone());
+                let (tx, rx) = oneshot::channel();
+                let res = self
+                    .context
+                    .storage_queue
+                    .send_timeout((cmd, tx), Duration::from_millis(1_000))
+                    .await;
+
+                if let Err(_) = res {
+                    return error_response("timeout while sending to storage".to_string());
+                }
+
+                match rx.await {
+                    Ok(Ok(None)) => vec![Token::BulkString(None)],
+                    Ok(Ok(Some(value))) => vec![Token::BulkString(Some(value))],
+                    Ok(Err(_)) => error_response("internal storage error".to_string()),
+                    Err(_) => error_response("no response from storage".to_string()),
+                }
+            }
+            Command::Set(key, value) => {
+                let cmd = StorageCommand::Set(key.clone(), value.clone());
+                let (tx, rx) = oneshot::channel();
+                let res = self
+                    .context
+                    .storage_queue
+                    .send_timeout((cmd, tx), Duration::from_millis(1_000))
+                    .await;
+
+                if let Err(_) = res {
+                    return error_response("timeout while sending to storage".to_string());
+                }
+
+                match rx.await {
+                    Ok(Ok(None)) => vec![Token::SimpleString("OK".to_string())],
+                    Ok(Ok(Some(value))) => vec![Token::BulkString(Some(value))],
+                    Ok(Err(_)) => error_response("internal storage error".to_string()),
+                    Err(_) => error_response("no response from storage".to_string()),
+                }
+            }
         }
     }
+}
+
+fn error_response(msg: String) -> Vec<Token> {
+    vec![Token::Error(msg)]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn it_echoes() {
-        let cp = CommandProcessor {};
+    #[tokio::test]
+    async fn it_echoes() {
+        let cp = CommandProcessor::new(Context::dummy());
 
         let cmd = Command::Echo(vec![0u8, 1u8, 2u8]);
         let expected = vec![Token::BulkString(Some(vec![0u8, 1u8, 2u8]))];
 
-        assert_eq!(expected, cp.execute_command(&cmd));
+        let result = cp.execute_command(&cmd).await;
+
+        assert_eq!(expected, result);
     }
 }

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use crate::codec::Token;
 use crate::types::{Bytes, Key, Value};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Command {
     Echo(Value),
     Command,
@@ -11,7 +11,7 @@ pub enum Command {
     Set(Key, Value),
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, Eq, PartialEq)]
 pub enum CommandError {
     #[error("insufficient tokens")]
     InsufficientTokens,
@@ -25,7 +25,7 @@ pub enum CommandError {
 
 impl Command {
     pub fn from_tokens(tokens: &[Token]) -> Result<(Command, usize), CommandError> {
-        if tokens.len() == 0 {
+        if tokens.is_empty() {
             return Err(CommandError::InsufficientTokens);
         }
 
@@ -35,7 +35,7 @@ impl Command {
             "ECHO" => {
                 validate_length(length, ECHO_LENGTH)?;
                 let reply_token = string_token_as_bytes(tokens.get(2))?;
-                Ok((Command::Echo(reply_token.into()), ECHO_LENGTH + 1))
+                Ok((Command::Echo(reply_token), ECHO_LENGTH + 1))
             }
             "COMMAND" => {
                 validate_length(length, COMMAND_LENGTH)?;
@@ -45,14 +45,14 @@ impl Command {
                 validate_length(length, GET_LENGTH)?;
                 let key = string_token_as_bytes(tokens.get(2))?;
 
-                Ok((Command::Get(key.into()), GET_LENGTH + 1))
+                Ok((Command::Get(key), GET_LENGTH + 1))
             }
             "SET" => {
                 validate_length(length, SET_LENGTH)?;
                 let key = string_token_as_bytes(tokens.get(2))?;
                 let value = string_token_as_bytes(tokens.get(3))?;
 
-                Ok((Command::Set(key.into(), value.into()), SET_LENGTH + 1))
+                Ok((Command::Set(key, value), SET_LENGTH + 1))
             }
             unk => Err(CommandError::UnknownCommand(unk.to_string())),
         }

--- a/src/connection/conn.rs
+++ b/src/connection/conn.rs
@@ -48,7 +48,7 @@ impl Connection {
                     buffer.advance(pos);
                     tokens.push(token);
 
-                    if buffer.is_empty() && tokens.len() > 0 {
+                    if buffer.is_empty() && !tokens.is_empty() {
                         let (command, consumed) = match Command::from_tokens(&tokens) {
                             Ok(x) => x,
                             Err(CommandError::InsufficientTokens) => continue,

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -1,6 +1,7 @@
-use bytes::{Buf, BytesMut};
 use std::io::Cursor;
 use std::net::SocketAddr;
+
+use bytes::{Buf, BytesMut};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 

--- a/src/connection/connection.rs
+++ b/src/connection/connection.rs
@@ -19,12 +19,12 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub fn new(ctx: Context, id: ConnectionId, socket: TcpStream, addr: SocketAddr) -> Self {
+    pub fn new(context: Context, id: ConnectionId, socket: TcpStream, addr: SocketAddr) -> Self {
         Connection {
             id,
             socket,
             addr,
-            context: ctx,
+            context,
         }
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -10,7 +10,7 @@ mod tracker;
 pub use connection::{Connection, ConnectionId};
 pub use tracker::ConnectionTracker;
 
-pub use crate::server::Context;
+use crate::server::Context;
 
 #[derive(Clone)]
 pub struct ConnectionManager {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,14 +1,16 @@
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
 use tokio::net::TcpStream;
 
 mod connection;
 mod tracker;
 
-pub use crate::server::Context;
 pub use connection::{Connection, ConnectionId};
 pub use tracker::ConnectionTracker;
+
+pub use crate::server::Context;
 
 #[derive(Clone)]
 pub struct ConnectionManager {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -6,6 +6,7 @@ use tokio::net::TcpStream;
 mod connection;
 mod tracker;
 
+pub use crate::server::Context;
 pub use connection::{Connection, ConnectionId};
 pub use tracker::ConnectionTracker;
 
@@ -25,10 +26,15 @@ impl Default for ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn take_connection(&mut self, socket: TcpStream, addr: SocketAddr) -> ConnectionId {
+    pub async fn take_connection(
+        &mut self,
+        ctx: Context,
+        socket: TcpStream,
+        addr: SocketAddr,
+    ) -> ConnectionId {
         let id = self.latest_id.fetch_add(1, Ordering::SeqCst);
 
-        let mut connection = Connection::new(id, socket, addr);
+        let mut connection = Connection::new(ctx, id, socket, addr);
         log::info!("accepted new connection. id={}, addr={}", id, addr);
 
         let tracker = self.tracker.clone();

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,10 +4,10 @@ use std::sync::{Arc, Mutex};
 
 use tokio::net::TcpStream;
 
-mod connection;
+mod conn;
 mod tracker;
 
-pub use connection::{Connection, ConnectionId};
+pub use conn::{Connection, ConnectionId};
 pub use tracker::ConnectionTracker;
 
 use crate::server::Context;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -30,13 +30,13 @@ impl Default for ConnectionManager {
 impl ConnectionManager {
     pub async fn take_connection(
         &mut self,
-        ctx: Context,
+        context: Context,
         socket: TcpStream,
         addr: SocketAddr,
     ) -> ConnectionId {
         let id = self.latest_id.fetch_add(1, Ordering::SeqCst);
 
-        let mut connection = Connection::new(ctx, id, socket, addr);
+        let mut connection = Connection::new(context, id, socket, addr);
         log::info!("accepted new connection. id={}, addr={}", id, addr);
 
         let tracker = self.tracker.clone();

--- a/src/connection/tracker.rs
+++ b/src/connection/tracker.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+
 use tokio::task::JoinHandle;
 
 use super::ConnectionId;

--- a/src/connection/tracker.rs
+++ b/src/connection/tracker.rs
@@ -33,6 +33,4 @@ impl ConnectionTracker {
             self.connection_handles.remove(&id);
         }
     }
-
-    // TODO: clean up terminated connections
 }

--- a/src/connection/tracker.rs
+++ b/src/connection/tracker.rs
@@ -4,18 +4,10 @@ use tokio::task::JoinHandle;
 
 use super::ConnectionId;
 
+#[derive(Default)]
 pub struct ConnectionTracker {
     active_connections: HashSet<ConnectionId>,
     connection_handles: HashMap<ConnectionId, JoinHandle<()>>,
-}
-
-impl Default for ConnectionTracker {
-    fn default() -> Self {
-        Self {
-            active_connections: HashSet::new(),
-            connection_handles: HashMap::new(),
-        }
-    }
 }
 
 impl ConnectionTracker {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod command;
 pub mod connection;
 pub mod server;
 pub mod storage;
+pub mod types;
 pub mod worker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod codec;
 pub mod command;
 pub mod connection;
 pub mod server;
+pub mod storage;
 pub mod worker;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,10 +1,23 @@
+use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
 
 use crate::connection::ConnectionManager;
+use crate::storage::{InMemoryStorage, StorageSendQueue};
+
+// TODO: custom type that is wraps Vec<u8> and debug prints utf-8 string if possible, else bytes
 
 pub struct Server {
     listener: TcpListener,
     connection_manager: ConnectionManager,
+    storage: Arc<Mutex<InMemoryStorage>>,
+    context: Context,
+}
+
+#[derive(Clone)]
+pub struct Context {
+    pub storage_queue: StorageSendQueue,
 }
 
 impl Server {
@@ -12,17 +25,32 @@ impl Server {
         let listener = TcpListener::bind(addr).await?;
         let connection_manager = ConnectionManager::default();
 
+        let (tx, rx) = mpsc::channel(100); // TODO: tunable option?
+
+        let storage = Arc::new(Mutex::new(InMemoryStorage::new(rx)));
+        let context = Context::new(tx);
+
         Ok(Server {
             listener,
             connection_manager,
+            storage,
+            context,
         })
     }
 
     pub async fn run(&mut self) {
+        let storage = self.storage.clone();
+        let _storage_handle = tokio::spawn(async move {
+            let mut storage = storage.lock().await;
+            storage.run().await;
+        });
+
         loop {
             match self.listener.accept().await {
                 Ok((socket, addr)) => {
-                    self.connection_manager.take_connection(socket, addr).await;
+                    self.connection_manager
+                        .take_connection(self.context.clone(), socket, addr)
+                        .await;
                 }
                 Err(e) => {
                     log::error!("error accepting connection: {}", e);
@@ -34,5 +62,16 @@ impl Server {
     pub fn addr(&self) -> String {
         let local_addr = self.listener.local_addr().unwrap();
         format!("127.0.0.1:{}", local_addr.port())
+    }
+}
+
+impl Context {
+    pub fn new(storage_queue: StorageSendQueue) -> Self {
+        Self { storage_queue }
+    }
+
+    pub fn dummy() -> Self {
+        let (tx, _rx) = mpsc::channel(1);
+        Self { storage_queue: tx }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,7 +25,10 @@ impl Server {
         let listener = TcpListener::bind(addr).await?;
         let connection_manager = ConnectionManager::default();
 
-        let (tx, rx) = mpsc::channel(100); // TODO: tunable option?
+        // TODO: do experiments to determine what size channel makes sense.
+        // This should probably be an input parameter so it can be tuned
+        // based on hardware and use cases.
+        let (tx, rx) = mpsc::channel(10);
 
         let storage = Arc::new(Mutex::new(InMemoryStorage::new(rx)));
         let context = Context::new(tx);
@@ -68,10 +71,5 @@ impl Server {
 impl Context {
     pub fn new(storage_queue: StorageSendQueue) -> Self {
         Self { storage_queue }
-    }
-
-    pub fn dummy() -> Self {
-        let (tx, _rx) = mpsc::channel(1);
-        Self { storage_queue: tx }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,12 @@ pub struct Server {
     context: Context,
 }
 
+/// Context is used to pass dependencies into connection handlers and the command
+/// processor.
+///
+/// This is Clone and certain constraints will be upheld:
+///  - Anything which is present will be efficient to clone (or requires clone, like queues)
+///  - Any shared state will be wrapped in Arc<Mutex<>> or similar to ensure safety
 #[derive(Clone)]
 pub struct Context {
     pub storage_queue: StorageSendQueue,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,47 @@
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use std::collections::HashMap;
+
+pub enum StorageCommand {
+    Set(Vec<u8>, Vec<u8>),
+    Get(Vec<u8>),
+}
+
+pub struct InMemoryStorage {
+    data: HashMap<Vec<u8>, Vec<u8>>,
+    recv_queue: StorageRecvQueue,
+}
+
+pub type StorageRecvQueue = mpsc::Receiver<(
+    StorageCommand,
+    oneshot::Sender<Result<Option<Vec<u8>>, std::io::Error>>,
+)>;
+pub type StorageSendQueue = mpsc::Sender<(
+    StorageCommand,
+    oneshot::Sender<Result<Option<Vec<u8>>, std::io::Error>>,
+)>;
+
+impl InMemoryStorage {
+    pub fn new(recv_queue: StorageRecvQueue) -> Self {
+        let data = HashMap::new();
+
+        Self { data, recv_queue }
+    }
+
+    pub async fn run(&mut self) {
+        while let Some((cmd, tx)) = self.recv_queue.recv().await {
+            let response = match cmd {
+                StorageCommand::Set(key, value) => {
+                    self.data.insert(key, value);
+                    Ok(None)
+                }
+                StorageCommand::Get(key) => Ok(self.data.get(&key).cloned()),
+            };
+
+            if let Err(_) = tx.send(response) {
+                log::error!("could not return value to requester; early disconnection?");
+            }
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -41,7 +41,7 @@ impl InMemoryStorage {
                 StorageCommand::Get(key) => Ok(self.data.get(&key).cloned()),
             };
 
-            if let Err(_) = tx.send(response) {
+            if tx.send(response).is_err() {
                 log::error!("could not return value to requester; early disconnection?");
             }
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,25 +1,27 @@
+use std::collections::HashMap;
+
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
-use std::collections::HashMap;
+use crate::types::{Key, Value};
 
 pub enum StorageCommand {
-    Set(Vec<u8>, Vec<u8>),
-    Get(Vec<u8>),
+    Set(Key, Value),
+    Get(Key),
 }
 
 pub struct InMemoryStorage {
-    data: HashMap<Vec<u8>, Vec<u8>>,
+    data: HashMap<Key, Value>,
     recv_queue: StorageRecvQueue,
 }
 
 pub type StorageRecvQueue = mpsc::Receiver<(
     StorageCommand,
-    oneshot::Sender<Result<Option<Vec<u8>>, std::io::Error>>,
+    oneshot::Sender<Result<Option<Value>, std::io::Error>>,
 )>;
 pub type StorageSendQueue = mpsc::Sender<(
     StorageCommand,
-    oneshot::Sender<Result<Option<Vec<u8>>, std::io::Error>>,
+    oneshot::Sender<Result<Option<Value>, std::io::Error>>,
 )>;
 
 impl InMemoryStorage {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,11 @@
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Bytes(pub Vec<u8>);
+
+impl From<Vec<u8>> for Bytes {
+    fn from(t: Vec<u8>) -> Self {
+        Bytes(t)
+    }
+}
+
+pub type Key = Bytes;
+pub type Value = Bytes;


### PR DESCRIPTION
This creates a basic in-memory storage engine and wires it up to the GET and SET commands. To avoid passing each new object all the way down the tree, this introduces the `Context` struct which will be used to provide necessary information throughout the call stack (likely additions include configuration, transaction-related info, etc.).

I'm not happy with these things:

* The parsing of incoming tokens into a `Command` instance is very messy. That's out of scope for this PR, though, and will be future cleanup.
* There is repetition in the `execute_command` function where we do very similar things; however, there are enough differences that I'm not seeing a particularly useful abstraction here yet. I think this will become clearer with more implementations.

There are also a few new TODOs in the code (and one that I had neglected to remove but was fixed, which shows in the diff as removed now). I'm leaving those in for now so that I remember, but those should be fast follow PRs.

On my laptop (not a good benchmark, but what I have until I get some VMs provisioned), single-core is roughly 0.75x the throughput of redis and multi-core is 2x the throughput of redis. This is a good launching off point for profiling it and figuring out what's slowing it down and then making some good gains.