### PR TITLE
Add internal types and implement INCR and DECR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
-      
+
   linting:
     runs-on: ubuntu-latest
     permissions:
@@ -39,8 +39,8 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
-        
+          args: --all-features -D warnings
+
   formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -D warnings
+          args: --all-features -- -D warnings
 
   formatting:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ debug = 1
 
 [dependencies]
 
+# let's not reimplement integer parsing
+atoi = "1.0.0"
+
 # error tracking is cool
 thiserror = "1.0.35"
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use thiserror::Error;
 
-use crate::types::Bytes;
+use crate::types::Blob;
 
 pub const CRLF: &str = "\r\n";
 
@@ -15,8 +15,8 @@ pub enum Token {
     Array(i64),
 }
 
-impl From<Bytes> for Token {
-    fn from(b: Bytes) -> Self {
+impl From<Blob> for Token {
+    fn from(b: Blob) -> Self {
         Token::BulkString(Some(b.0))
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -26,9 +26,6 @@ pub enum ReadError {
     #[error("not implemented")]
     NotImplemented,
 
-    #[error("incomplete read")]
-    Incomplete,
-
     #[error("malformed input")]
     Malformed(&'static str),
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -32,14 +32,8 @@ pub enum ReadError {
     #[error("insufficient bytes")]
     InsufficientBytes(std::io::Error),
 
-    #[error("unknown reason")]
-    Failed(std::io::Error),
-}
-
-impl From<std::io::Error> for ReadError {
-    fn from(err: std::io::Error) -> ReadError {
-        ReadError::Failed(err)
-    }
+    #[error("unknown reason: {0}")]
+    Failed(#[from] std::io::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,7 +4,7 @@ use tokio::sync::oneshot;
 
 use crate::codec::Token;
 use crate::server::Context;
-use crate::storage::StorageCommand;
+use crate::storage::{StorageCommand, StorageError};
 use crate::types::{Blob, Value};
 
 mod types;
@@ -46,87 +46,69 @@ impl CommandProcessor {
                 ExecutionResult(vec![Token::BulkString(Some("ECHO".bytes().collect()))])
             }
             Command::Get(key) => {
-                let cmd = StorageCommand::Get(key.clone());
-                let (tx, rx) = oneshot::channel();
-                let res = self
-                    .context
-                    .storage_queue
-                    .send_timeout((cmd, tx), Duration::from_millis(1_000))
-                    .await;
-
-                if res.is_err() {
-                    return "timeout while sending to storage".into();
-                }
-
-                match rx.await {
+                self.execute_command_helper(StorageCommand::Get(key.clone()), |res| match res {
                     Ok(Ok(None)) => ExecutionResult(vec![Token::BulkString(None)]),
                     Ok(Ok(Some(value))) => ExecutionResult(value_to_tokens(value)),
                     Ok(Err(_)) => "internal storage error".into(),
                     Err(_) => "no response from storage".into(),
-                }
+                })
+                .await
             }
             Command::Set(key, value) => {
-                let cmd = StorageCommand::Set(key.clone(), Value::Blob(value.clone()));
-                let (tx, rx) = oneshot::channel();
-                let res = self
-                    .context
-                    .storage_queue
-                    .send_timeout((cmd, tx), Duration::from_millis(1_000))
-                    .await;
-
-                if res.is_err() {
-                    return "timeout while sending to storage".into();
-                }
-
-                match rx.await {
-                    Ok(Ok(None)) => ExecutionResult(vec![Token::SimpleString("OK".to_string())]),
-                    Ok(Ok(Some(value))) => ExecutionResult(value_to_tokens(value)),
-                    Ok(Err(_)) => "internal storage error".into(),
-                    Err(_) => "no response from storage".into(),
-                }
+                self.execute_command_helper(
+                    StorageCommand::Set(key.clone(), Value::Blob(value.clone())),
+                    |res| match res {
+                        Ok(Ok(None)) => {
+                            ExecutionResult(vec![Token::SimpleString("OK".to_string())])
+                        }
+                        Ok(Ok(Some(value))) => ExecutionResult(value_to_tokens(value)),
+                        Ok(Err(_)) => "internal storage error".into(),
+                        Err(_) => "no response from storage".into(),
+                    },
+                )
+                .await
             }
             Command::Incr(key) => {
-                let cmd = StorageCommand::Incr(key.clone());
-                let (tx, rx) = oneshot::channel();
-                let res = self
-                    .context
-                    .storage_queue
-                    .send_timeout((cmd, tx), Duration::from_millis(1_000))
-                    .await;
-
-                if res.is_err() {
-                    return "timeout while sending to storage".into();
-                }
-
-                match rx.await {
+                self.execute_command_helper(StorageCommand::Incr(key.clone()), |res| match res {
                     Ok(Ok(Some(value))) => ExecutionResult(value_to_tokens(value)),
                     Ok(Ok(None)) => "invalid response from storage".into(),
-                    Ok(Err(_)) => "internal storage error".into(),
+                    Ok(Err(err)) => storage_error_to_string(err).into(),
                     Err(_) => "no response from storage".into(),
-                }
+                })
+                .await
             }
             Command::Decr(key) => {
-                let cmd = StorageCommand::Decr(key.clone());
-                let (tx, rx) = oneshot::channel();
-                let res = self
-                    .context
-                    .storage_queue
-                    .send_timeout((cmd, tx), Duration::from_millis(1_000))
-                    .await;
-
-                if res.is_err() {
-                    return "timeout while sending to storage".into();
-                }
-
-                match rx.await {
+                self.execute_command_helper(StorageCommand::Decr(key.clone()), |res| match res {
                     Ok(Ok(Some(value))) => ExecutionResult(value_to_tokens(value)),
                     Ok(Ok(None)) => "invalid response from storage".into(),
-                    Ok(Err(_)) => "internal storage error".into(),
+                    Ok(Err(err)) => storage_error_to_string(err).into(),
                     Err(_) => "no response from storage".into(),
-                }
+                })
+                .await
             }
             Command::Unknown(cmd) => return format!("{} is not implemented :(", cmd).into(),
         }
+    }
+
+    async fn execute_command_helper(
+        &self,
+        cmd: StorageCommand,
+        f: impl FnOnce(
+            Result<Result<Option<Value>, StorageError>, tokio::sync::oneshot::error::RecvError>,
+        ) -> ExecutionResult,
+    ) -> ExecutionResult {
+        let (tx, rx) = oneshot::channel();
+        let res = self
+            .context
+            .storage_queue
+            .send_timeout((cmd, tx), Duration::from_millis(1_000))
+            .await;
+
+        if res.is_err() {
+            return "timeout while sending to storage".into();
+        }
+
+        f(rx.await)
     }
 }
 
@@ -137,6 +119,16 @@ fn value_to_tokens(value: Value) -> Vec<Token> {
             let b = i.to_string().into_bytes();
             vec![Blob(b).into()]
         }
+    }
+}
+
+fn storage_error_to_string(error: StorageError) -> &'static str {
+    match error {
+        StorageError::NotAnInteger => {
+            "WRONGTYPE Operation against a key holding the wrong kind of value"
+        }
+        StorageError::Overflow => "ERR increment or decrement would overflow",
+        StorageError::Failed(_) => "ERR unknown storage failure",
     }
 }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -84,6 +84,14 @@ impl CommandProcessor {
                     Err(_) => "no response from storage".into(),
                 }
             }
+            Command::Decr(_key) => {
+                // TODO
+                return format!("DECR is not implemented yet").into()
+            }
+            Command::Incr(_key) => {
+                // TODO
+                return format!("INCR is not implemented yet").into()
+            }
             Command::Unknown(cmd) => {
                 return format!("{} is not implemented", cmd).into()
             }
@@ -96,7 +104,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::types::Bytes;
+    use crate::types::Blob;
 
     #[tokio::test]
     async fn it_echoes() {
@@ -104,7 +112,7 @@ mod tests {
         let context = Context::new(tx);
         let cp = CommandProcessor::new(context);
 
-        let cmd = Command::Echo(Bytes(vec![0u8, 1u8, 2u8]));
+        let cmd = Command::Echo(Blob(vec![0u8, 1u8, 2u8]));
         let expected = vec![Token::BulkString(Some(vec![0u8, 1u8, 2u8]))];
 
         let result = cp.execute_command(&cmd).await.0;

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -1,14 +1,20 @@
 use thiserror::Error;
 
 use crate::codec::Token;
-use crate::types::{Bytes, Key, Value};
+use crate::types::{Blob, Key, Value};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Command {
     Echo(Value),
+
     Command,
+
     Get(Key),
     Set(Key, Value),
+
+    Decr(Key),
+    Incr(Key),
+
     Unknown(String),
 }
 
@@ -84,7 +90,7 @@ fn get_command(tokens: &[Token]) -> Result<(usize, String), CommandError> {
     Ok((length, cmd))
 }
 
-fn string_token_as_bytes(token: Option<&Token>) -> Result<Bytes, CommandError> {
+fn string_token_as_bytes(token: Option<&Token>) -> Result<Blob, CommandError> {
     match token {
         Some(Token::SimpleString(s)) => Ok(s.bytes().collect::<Vec<u8>>().into()),
         Some(Token::BulkString(Some(s))) => Ok(s.clone().into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anode_kv::server::Server;
 
-#[tokio::main(flavor= "multi_thread", worker_threads=8)]
+#[tokio::main(flavor = "multi_thread", worker_threads = 8)]
 async fn main() -> std::io::Result<()> {
     env_logger::init();
     let addr = "127.0.0.1:11311";

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,8 +7,6 @@ use tokio::sync::Mutex;
 use crate::connection::ConnectionManager;
 use crate::storage::{InMemoryStorage, StorageSendQueue};
 
-// TODO: custom type that is wraps Vec<u8> and debug prints utf-8 string if possible, else bytes
-
 pub struct Server {
     listener: TcpListener,
     connection_manager: ConnectionManager,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,14 +21,8 @@ pub enum StorageError {
     #[error("not an integer")]
     NotAnInteger,
 
-    #[error("unknown reason")]
-    Failed(std::io::Error),
-}
-
-impl From<std::io::Error> for StorageError {
-    fn from(err: std::io::Error) -> StorageError {
-        StorageError::Failed(err)
-    }
+    #[error("unknown reason: {0}")]
+    Failed(#[from] std::io::Error),
 }
 
 pub struct InMemoryStorage {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -73,15 +73,13 @@ impl InMemoryStorage {
         match entry {
             Value::Int(i) => {
                 *i = safe_add(*i, amount)?;
-                return Ok(Some(Value::Int(*i)));
+                Ok(Some(Value::Int(*i)))
             }
             Value::Blob(Blob(b)) => match atoi::atoi::<i64>(b) {
-                None => {
-                    return Err(StorageError::NotAnInteger);
-                }
+                None => Err(StorageError::NotAnInteger),
                 Some(i) => {
                     *entry = Value::Int(safe_add(i, amount)?);
-                    return Ok(Some(entry.clone()));
+                    Ok(Some(entry.clone()))
                 }
             },
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -69,12 +69,8 @@ impl InMemoryStorage {
                 Ok(None)
             }
             StorageCommand::Get(key) => Ok(self.data.get(&key).cloned()),
-            StorageCommand::Incr(key) => {
-                self.handle_add(key, 1).await
-            }
-            StorageCommand::Decr(key) => {
-                self.handle_add(key, -1).await
-            }
+            StorageCommand::Incr(key) => self.handle_add(key, 1).await,
+            StorageCommand::Decr(key) => self.handle_add(key, -1).await,
         }
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
-use crate::types::{Key, Value};
+use crate::types::{Blob, Key, Value};
 
 pub enum StorageCommand {
     Set(Key, Value),
     Get(Key),
+    Incr(Key),
+    Decr(Key),
 }
 
 pub struct InMemoryStorage {
@@ -33,17 +35,67 @@ impl InMemoryStorage {
 
     pub async fn run(&mut self) {
         while let Some((cmd, tx)) = self.recv_queue.recv().await {
-            let response = match cmd {
-                StorageCommand::Set(key, value) => {
-                    self.data.insert(key, value);
-                    Ok(None)
-                }
-                StorageCommand::Get(key) => Ok(self.data.get(&key).cloned()),
-            };
+            let response = self.handle_cmd(cmd).await;
 
             if tx.send(response).is_err() {
                 log::error!("could not return value to requester; early disconnection?");
             }
+        }
+    }
+
+    pub async fn handle_cmd(
+        &mut self,
+        cmd: StorageCommand,
+    ) -> Result<Option<Value>, std::io::Error> {
+        match cmd {
+            StorageCommand::Set(key, value) => {
+                self.data.insert(key, value);
+                Ok(None)
+            }
+            StorageCommand::Get(key) => Ok(self.data.get(&key).cloned()),
+            StorageCommand::Incr(key) => {
+                let entry = self.data.entry(key).or_insert(Value::Int(0));
+                match entry {
+                    Value::Int(i) => {
+                        *i += 1;
+                        return Ok(Some(Value::Int(*i)));
+                    }
+                    Value::Blob(Blob(b)) => match atoi::atoi::<i64>(b) {
+                        None => {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                "not an integer",
+                            ));
+                        }
+                        Some(i) => {
+                            *entry = Value::Int(i + 1);
+                            return Ok(Some(entry.clone()));
+                        }
+                    },
+                }
+            }
+            StorageCommand::Decr(key) => {
+                let entry = self.data.entry(key).or_insert(Value::Int(0));
+                match entry {
+                    Value::Int(i) => {
+                        *i -= 1;
+                        return Ok(Some(Value::Int(*i)));
+                    }
+                    Value::Blob(Blob(b)) => match atoi::atoi::<i64>(b) {
+                        None => {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                "not an integer",
+                            ));
+                        }
+                        Some(i) => {
+                            *entry = Value::Int(i - 1);
+                            return Ok(Some(entry.clone()));
+                        }
+                    },
+                }
+            }
+
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,18 +1,18 @@
 use std::fmt::{Debug, Error, Formatter};
 
 #[derive(Clone, Eq, Hash, PartialEq)]
-pub struct Bytes(pub Vec<u8>);
+pub struct Blob(pub Vec<u8>);
 
-impl From<Vec<u8>> for Bytes {
+impl From<Vec<u8>> for Blob {
     fn from(t: Vec<u8>) -> Self {
-        Bytes(t)
+        Blob(t)
     }
 }
 
-pub type Key = Bytes;
-pub type Value = Bytes;
+pub type Key = Blob;
+pub type Value = Blob;
 
-impl Debug for Bytes {
+impl Debug for Blob {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(f, "{}", String::from_utf8_lossy(&self.0))
     }
@@ -20,16 +20,16 @@ impl Debug for Bytes {
 
 #[cfg(test)]
 mod test {
-    use super::Bytes;
+    use super::Blob;
 
-    impl From<&str> for Bytes {
+    impl From<&str> for Blob {
         fn from(t: &str) -> Self {
-            Bytes(Vec::from(t))
+            Blob(Vec::from(t))
         }
     }
 
     #[test]
     fn debug_format_is_readable() {
-        assert_eq!(format!("{:?}", &Bytes::from("foo")), "foo");
+        assert_eq!(format!("{:?}", &Blob::from("foo")), "foo");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+//use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Error, Formatter};
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -10,7 +11,20 @@ impl From<Vec<u8>> for Blob {
 }
 
 pub type Key = Blob;
-pub type Value = Blob;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Value {
+    Blob(Blob),
+    //Set(HashSet<Blob>),
+    //Hash(HashMap<Blob,Blob>),
+    Int(i64),
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(t: Vec<u8>) -> Self {
+        Value::Blob(t.into())
+    }
+}
 
 impl Debug for Blob {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {

--- a/tests/incr_test.rs
+++ b/tests/incr_test.rs
@@ -1,0 +1,4 @@
+//use anode_kv::server::Server;
+
+#[tokio::test]
+async fn it_can_incr_keys() {}

--- a/tests/incr_test.rs
+++ b/tests/incr_test.rs
@@ -1,4 +1,77 @@
-//use anode_kv::server::Server;
+use anode_kv::server::Server;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::Duration;
 
 #[tokio::test]
-async fn it_can_incr_keys() {}
+async fn it_can_incr_and_decr_keys() {
+    let mut server = Server::create("127.0.0.1:0").await.unwrap();
+    let addr = server.addr();
+    tokio::spawn(async move {
+        server.run().await;
+    });
+
+    test_command_response(&addr, cmd_incr("x").as_bytes(), resp_bulk("1").as_bytes()).await;
+    test_command_response(&addr, cmd_incr("x").as_bytes(), resp_bulk("2").as_bytes()).await;
+
+    test_command_response(
+        &addr,
+        cmd_set("y", "3").as_bytes(),
+        resp_simple("OK").as_bytes(),
+    )
+    .await;
+    test_command_response(&addr, cmd_incr("y").as_bytes(), resp_bulk("4").as_bytes()).await;
+    test_command_response(&addr, cmd_incr("y").as_bytes(), resp_bulk("5").as_bytes()).await;
+
+    test_command_response(
+        &addr,
+        cmd_set("z", "-4").as_bytes(),
+        resp_simple("OK").as_bytes(),
+    )
+    .await;
+    test_command_response(&addr, cmd_decr("z").as_bytes(), resp_bulk("-5").as_bytes()).await;
+    test_command_response(&addr, cmd_decr("z").as_bytes(), resp_bulk("-6").as_bytes()).await;
+
+    test_command_response(&addr, cmd_decr("a").as_bytes(), resp_bulk("-1").as_bytes()).await;
+    test_command_response(&addr, cmd_decr("a").as_bytes(), resp_bulk("-2").as_bytes()).await;
+}
+
+async fn test_command_response(addr: &str, command: &[u8], expected: &[u8]) {
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("failed to connect to server");
+
+    stream
+        .write_all(command)
+        .await
+        .expect("failed write into stream");
+
+    let mut buffer = vec![0; expected.len()];
+
+    let stream_read_promise = stream.read_exact(&mut buffer[..]);
+
+    if let Err(_) = tokio::time::timeout(Duration::from_millis(100), stream_read_promise).await {
+        panic!("response did not return within 100ms");
+    }
+
+    assert_eq!(buffer, expected);
+}
+
+fn cmd_set(key: &str, value: &str) -> String {
+    format!("*3\r\n+SET\r\n+{}\r\n+{}\r\n", key, value)
+}
+
+fn cmd_incr(key: &str) -> String {
+    format!("*2\r\n+INCR\r\n+{}\r\n", key)
+}
+
+fn cmd_decr(key: &str) -> String {
+    format!("*2\r\n+DECR\r\n+{}\r\n", key)
+}
+
+fn resp_simple(value: &str) -> String {
+    format!("+{}\r\n", value)
+}
+
+fn resp_bulk(value: &str) -> String {
+    format!("${}\r\n{}\r\n", value.len(), value)
+}


### PR DESCRIPTION
This implements internal types in the storage engine instead of having everything as a blob of bytes, and adds the INCR and DECR commands. There is as lot of quality of life refactoring here, too, to reduce repetition which was otherwise to be introduced by this PR.

The changes in this PR are:

- Introduce a new `StorageError` type for better error handling of things coming back from storage, so integer overflows can be handled with a nice error instead of "internal server error" equivalents
- Switch `Value` from `Blob` to an enum which may be `Blob(Blob)` (still wrapped as a blob internally to keep the nice debug printing) or `Int(i64)`, with two other variants commented out for a future PR (not the best cleanliness, but I'm coming back to them soon)
- Implement INCR and DECR, with refactoring to make all new commands also significantly easier to implement
- Add an integration test covering INCR/DECR, and a little bit of SET; this also introduces a pattern which will make most of the commands pretty easy to test! I think there's some more to do here but I'm happy with it for now.

A few notable changes that are tangential to the goal of this PR:

- Renamed `Bytes` to `Blob` to avoid confusion with the external crate's type, `bytes::Bytes`, which we also use
- Removed an unused `ReadError` variant