### PR TITLE
Add command-line configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ perf.data*
 
 # Test data
 .tmp/
+tmp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ console-subscriber = "0.1.8"
 # handy for reading contiguous streams of... bytes.
 bytes = "1.2.1"
 
+# clap if you like command line arguments
+clap = { version = "4.0.15", features = ["derive"] }
+
 [dev-dependencies]
 
 criterion = "0.4.0"

--- a/launch_load.sh
+++ b/launch_load.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-podman run --network=host --rm redislabs/memtier_benchmark:1.3.0 -p 11311 --hide-histogram -t 20 -c 10 -n 50000 -d 65536
+#podman run --network=host --rm redislabs/memtier_benchmark:1.3.0 -p 11311 --hide-histogram -t 20 -c 10 -n 50000 -d 65536
+podman run --network=host --rm redislabs/memtier_benchmark:1.3.0 -p 11311 --hide-histogram -t 20 -c 10 -n 50000 -d 1024

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -150,12 +150,12 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::types::Blob;
+    use crate::{config::Config, types::Blob};
 
     #[tokio::test]
     async fn it_echoes() {
         let (tx, _rx) = mpsc::channel(1);
-        let context = Context::new(tx);
+        let context = Context::new(tx, Config::default());
         let cp = CommandProcessor::new(context);
 
         let cmd = Command::Echo(Blob(vec![0u8, 1u8, 2u8]));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,31 @@
+use clap::Parser;
+
+#[derive(Debug, Parser, Clone)]
+pub struct Config {
+    // How many worker threads to use
+    #[arg(short, long, default_value_t = 8)]
+    pub worker_threads: usize,
+
+    // Size channel for sending to the storage processor
+    #[arg(long, default_value_t = 8)]
+    pub storage_queue_size: usize,
+
+    // Address to bind server to
+    #[arg(short, long, default_value = "127.0.0.1:11311")]
+    pub address: String,
+
+    // Base filepath for durable storage
+    #[arg(short, long, default_value = "./tmp/log")]
+    pub storage_basepath: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            worker_threads: 8,
+            storage_queue_size: 10,
+            address: "127.0.0.1:11311".to_string(),
+            storage_basepath: "./tmp/log".to_string(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate test;
 
 pub mod codec;
 pub mod command;
+pub mod config;
 pub mod connection;
 pub mod server;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,22 @@
+use anode_kv::config::Config;
 use anode_kv::server::Server;
+use clap::Parser;
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 8)]
-async fn main() -> std::io::Result<()> {
+fn main() {
     env_logger::init();
-    let addr = "127.0.0.1:11311";
-    let mut server = Server::create(addr).await.expect("should launch");
-    let handle = tokio::spawn(async move {
-        server.run().await;
-    });
-    handle.await.expect("should shut down gracefully");
-    Ok(())
+    let config: Config = Config::parse();
+    println!("args: {:?}", config);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(config.worker_threads)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let mut server = Server::create(config).await.expect("should launch");
+            let handle = tokio::spawn(async move {
+                server.run().await;
+            });
+            handle.await.expect("should shut down gracefully");
+        });
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
+use crate::server::Context;
 pub use crate::transaction::{TransactionLog, TransactionLogError};
 use crate::types::{Blob, Key, Value};
 
@@ -47,21 +48,23 @@ pub type StorageSendQueue = mpsc::Sender<(
 )>;
 
 impl InMemoryStorage {
-    pub fn new(recv_queue: StorageRecvQueue) -> Self {
+    pub fn new(recv_queue: StorageRecvQueue, context: Context) -> Self {
         let data = HashMap::new();
         // TODO: pass this in instead
-        let log = TransactionLog::new("log").expect("creating transaction log shold not fail");
+        let log = TransactionLog::new(context.config.clone())
+            .expect("creating transaction log shold not fail");
+        let durable = true;
 
         Self {
             data,
             recv_queue,
             log,
-            durable: true,
+            durable,
         }
     }
 
-    pub async fn from_log(recv_queue: StorageRecvQueue) -> Self {
-        let mut store = Self::new(recv_queue);
+    pub async fn from_log(recv_queue: StorageRecvQueue, context: Context) -> Self {
+        let mut store = Self::new(recv_queue, context);
 
         println!("starting log read");
         store.disable_durability();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -51,7 +51,7 @@ impl InMemoryStorage {
     pub fn new(recv_queue: StorageRecvQueue, context: Context) -> Self {
         let data = HashMap::new();
         // TODO: pass this in instead
-        let log = TransactionLog::new(context.config.clone())
+        let log = TransactionLog::new(context.config)
             .expect("creating transaction log shold not fail");
         let durable = true;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -51,8 +51,8 @@ impl InMemoryStorage {
     pub fn new(recv_queue: StorageRecvQueue, context: Context) -> Self {
         let data = HashMap::new();
         // TODO: pass this in instead
-        let log = TransactionLog::new(context.config)
-            .expect("creating transaction log shold not fail");
+        let log =
+            TransactionLog::new(context.config).expect("creating transaction log shold not fail");
         let durable = true;
 
         Self {

--- a/tests/connection_test.rs
+++ b/tests/connection_test.rs
@@ -1,3 +1,4 @@
+use anode_kv::config::Config;
 use anode_kv::server::Server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -5,7 +6,7 @@ use tokio::time::Duration;
 
 #[tokio::test]
 async fn it_can_accept_connections() {
-    let mut server = Server::create("127.0.0.1:0").await.unwrap();
+    let mut server = Server::create(create_config()).await.unwrap();
     let addr = server.addr();
     tokio::spawn(async move {
         server.run().await;
@@ -17,7 +18,7 @@ async fn it_can_accept_connections() {
 
 #[tokio::test]
 async fn it_can_accept_multiple_connections() {
-    let mut server = Server::create("127.0.0.1:0").await.unwrap();
+    let mut server = Server::create(create_config()).await.unwrap();
     let addr = server.addr();
     tokio::spawn(async move {
         server.run().await;
@@ -57,4 +58,10 @@ async fn connect_and_request(addr: String) -> TcpStream {
     assert_eq!(buffer, expected_response);
 
     stream
+}
+
+fn create_config() -> Config {
+    let mut config = Config::default();
+    config.address = "127.0.0.1:0".to_string();
+    config
 }

--- a/tests/connection_test.rs
+++ b/tests/connection_test.rs
@@ -63,5 +63,10 @@ async fn connect_and_request(addr: String) -> TcpStream {
 fn create_config() -> Config {
     let mut config = Config::default();
     config.address = "127.0.0.1:0".to_string();
+
+    // ensure that the tmp directory exists, since the server expects it to
+    // already be created
+    std::fs::create_dir_all("./tmp").unwrap();
+
     config
 }

--- a/tests/incr_test.rs
+++ b/tests/incr_test.rs
@@ -1,10 +1,11 @@
+use anode_kv::config::Config;
 use anode_kv::server::Server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::Duration;
 
 #[tokio::test]
 async fn it_can_incr_and_decr_keys() {
-    let mut server = Server::create("127.0.0.1:0").await.unwrap();
+    let mut server = Server::create(create_config()).await.unwrap();
     let addr = server.addr();
     tokio::spawn(async move {
         server.run().await;
@@ -74,4 +75,10 @@ fn resp_simple(value: &str) -> String {
 
 fn resp_bulk(value: &str) -> String {
     format!("${}\r\n{}\r\n", value.len(), value)
+}
+
+fn create_config() -> Config {
+    let mut config = Config::default();
+    config.address = "127.0.0.1:0".to_string();
+    config
 }


### PR DESCRIPTION
This creates preliminary command-line configuration options and plumbs it to pass these through to their consumers. The initial options are for configuring number of worker threads, size of a queue, bind address, and storage base path, and more will come as needed.

These allow easy tuning for benchmarks and optimizations.

More should be added based on #7 , but these are what's available for what's implemented right now. In the future, as we add features, the corresponding flags should be added.