### PR TITLE
Separate out transaction handling into its own worker

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -155,7 +155,8 @@ mod tests {
     #[tokio::test]
     async fn it_echoes() {
         let (tx, _rx) = mpsc::channel(1);
-        let context = Context::new(tx, Config::default());
+        let (ttx, _rx) = mpsc::channel(1);
+        let context = Context::new(tx, ttx, Config::default());
         let cp = CommandProcessor::new(context);
 
         let cmd = Command::Echo(Blob(vec![0u8, 1u8, 2u8]));

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,14 @@ pub struct Config {
     // Base filepath for durable storage
     #[arg(short, long, default_value = "./tmp/log")]
     pub storage_basepath: String,
+
+    // Reconstruct the database from the log
+    #[arg(short, long, default_value_t = false)]
+    pub read_log: bool,
+
+    // Size channel for sending transactions to the transaction worker
+    #[arg(long, default_value_t = 100)]
+    pub transaction_queue_size: usize,
 }
 
 impl Default for Config {
@@ -24,8 +32,10 @@ impl Default for Config {
         Self {
             worker_threads: 8,
             storage_queue_size: 10,
+            transaction_queue_size: 100,
             address: "127.0.0.1:11311".to_string(),
             storage_basepath: "./tmp/log".to_string(),
+            read_log: false,
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 use crate::config::Config;
 use crate::connection::ConnectionManager;
 use crate::storage::{InMemoryStorage, StorageSendQueue};
-use crate::transaction::{TransactionWorker, TransactionSendQueue};
+use crate::transaction::{TransactionSendQueue, TransactionWorker};
 
 pub struct Server {
     listener: TcpListener,
@@ -91,7 +91,11 @@ impl Server {
 }
 
 impl Context {
-    pub fn new(storage_queue: StorageSendQueue, transaction_queue: TransactionSendQueue, config: Config) -> Self {
+    pub fn new(
+        storage_queue: StorageSendQueue,
+        transaction_queue: TransactionSendQueue,
+        config: Config,
+    ) -> Self {
         Self {
             storage_queue,
             transaction_queue,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,8 +4,10 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
+use crate::config::Config;
 use crate::server::Context;
-pub use crate::transaction::{TransactionLog, TransactionLogError};
+use crate::transaction::TransactionLog;
+pub use crate::transaction::{TransactionLogError, TransactionSendQueue};
 use crate::types::{Blob, Key, Value};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -34,7 +36,7 @@ pub enum StorageError {
 pub struct InMemoryStorage {
     data: HashMap<Key, Value>,
     recv_queue: StorageRecvQueue,
-    log: TransactionLog,
+    transaction_queue: TransactionSendQueue,
     durable: bool,
 }
 
@@ -50,33 +52,29 @@ pub type StorageSendQueue = mpsc::Sender<(
 impl InMemoryStorage {
     pub fn new(recv_queue: StorageRecvQueue, context: Context) -> Self {
         let data = HashMap::new();
-        // TODO: pass this in instead
-        let log =
-            TransactionLog::new(context.config).expect("creating transaction log shold not fail");
         let durable = true;
 
         Self {
             data,
             recv_queue,
-            log,
+            transaction_queue: context.transaction_queue,
             durable,
         }
     }
 
-    pub async fn from_log(recv_queue: StorageRecvQueue, context: Context) -> Self {
-        let mut store = Self::new(recv_queue, context);
-
+    pub async fn load_from_log(&mut self, config: Config) {
         println!("starting log read");
-        store.disable_durability();
+        self.disable_durability();
         let mut count: usize = 0;
-        for cmd in store.log.read().unwrap() {
-            store.handle_cmd(cmd).await.expect("should work");
+
+        let log = TransactionLog::new(config).expect("should be able to read from the log");
+        for cmd in log.read().unwrap() {
+            self.handle_cmd(cmd).await.expect("should work");
             count += 1;
         }
-        store.enable_durability();
-        println!("finished log read; {} records", count);
 
-        store
+        self.enable_durability();
+        println!("finished log read; {} records", count);
     }
 
     pub async fn run(&mut self) {
@@ -90,7 +88,7 @@ impl InMemoryStorage {
     }
 
     pub async fn handle_cmd(&mut self, cmd: StorageCommand) -> Result<Option<Value>, StorageError> {
-        self.record_cmd(&cmd)?;
+        self.record_cmd(&cmd).await?;
         match cmd {
             StorageCommand::Set(key, value) => {
                 self.data.insert(key, value);
@@ -127,14 +125,10 @@ impl InMemoryStorage {
         self.durable = false;
     }
 
-    fn record_cmd(&self, cmd: &StorageCommand) -> Result<(), StorageError> {
+    async fn record_cmd(&self, cmd: &StorageCommand) -> Result<(), StorageError> {
         if self.durable {
-            match cmd {
-                StorageCommand::Get(_) => {}
-                _ => {
-                    self.log.record(cmd)?;
-                }
-            };
+            let (tx, _rx) = oneshot::channel();
+            self.transaction_queue.send((vec![cmd.clone()], tx)).await.expect("sending to transaction log failed");
         }
         Ok(())
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -128,7 +128,10 @@ impl InMemoryStorage {
     async fn record_cmd(&self, cmd: &StorageCommand) -> Result<(), StorageError> {
         if self.durable {
             let (tx, _rx) = oneshot::channel();
-            self.transaction_queue.send((vec![cmd.clone()], tx)).await.expect("sending to transaction log failed");
+            self.transaction_queue
+                .send((vec![cmd.clone()], tx))
+                .await
+                .expect("sending to transaction log failed");
         }
         Ok(())
     }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -32,10 +32,10 @@ pub type TransactionSendQueue = mpsc::Sender<(
 
 impl TransactionWorker {
     pub fn new(recv_queue: TransactionRecvQueue, config: Config) -> Self {
-        return TransactionWorker {
+        TransactionWorker {
             recv_queue,
             log: TransactionLog::new(config).expect("creating transaction log shold not fail"),
-        };
+        }
     }
 
     pub async fn run(&mut self) {
@@ -286,7 +286,7 @@ mod tests {
 
         let log = TransactionLog::new(config.clone()).expect("should create log");
         for cmd in &commands {
-            log.record(&cmd).expect("should record command");
+            log.record(cmd).expect("should record command");
         }
 
         let read_log = TransactionLog::new(config).expect("should create log");
@@ -299,12 +299,12 @@ mod tests {
     /// sets up the tmp dir including cleaning it beforehand, in case it exists.
     fn setup_tmp_dir(dir: &str) {
         cleanup_tmp_dir(dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(dir).unwrap();
     }
 
     /// sets up the tmp dir including cleaning it beforehand, in case it exists.
     fn cleanup_tmp_dir(dir: &str) {
-        match std::fs::remove_dir_all(&dir) {
+        match std::fs::remove_dir_all(dir) {
             Err(_) => println!("yay, it was already cleaned up!"),
             Ok(_) => println!("cleaning up after someone else"),
         }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,6 +1,8 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
 use thiserror::Error;
 
@@ -12,6 +14,45 @@ use crate::types::{Blob, Value};
 pub enum TransactionLogError {
     #[error("unknown reason: {0}")]
     Failed(#[from] std::io::Error),
+}
+
+pub struct TransactionWorker {
+    log: TransactionLog,
+    recv_queue: TransactionRecvQueue,
+}
+
+pub type TransactionRecvQueue = mpsc::Receiver<(
+    Vec<StorageCommand>,
+    oneshot::Sender<Result<(), TransactionLogError>>,
+)>;
+pub type TransactionSendQueue = mpsc::Sender<(
+    Vec<StorageCommand>,
+    oneshot::Sender<Result<(), TransactionLogError>>,
+)>;
+
+
+impl TransactionWorker {
+    pub fn new(recv_queue: TransactionRecvQueue, config: Config) -> Self {
+        return TransactionWorker {
+            recv_queue,
+            log: TransactionLog::new(config).expect("creating transaction log shold not fail"),
+        }
+    }
+
+    pub async fn run(&mut self) {
+        while let Some((cmds, tx)) = self.recv_queue.recv().await {
+            let response = self.handle_transaction(cmds).await;
+
+            if tx.send(response).is_err() {
+                log::debug!("could not return value to requester; presuming they did not want a value returned");
+            }
+        }
+    }
+
+    async fn handle_transaction(&self, cmds: Vec<StorageCommand>) -> Result<(), TransactionLogError> {
+        self.log.record_batch(&cmds[..])?;
+        Ok(())
+    }
 }
 
 pub struct TransactionLog {
@@ -39,6 +80,40 @@ impl TransactionLog {
 
     pub fn record(&self, cmd: &StorageCommand) -> Result<(), TransactionLogError> {
         let mut log = self.current_log.lock().unwrap();
+        self.write_to_log(&mut log, cmd)?;
+        Ok(())
+    }
+
+    pub fn record_batch(&self, cmds: &[StorageCommand]) -> Result<(), TransactionLogError> {
+        let mut log = self.current_log.lock().unwrap();
+        for cmd in cmds {
+            self.write_to_log(&mut log, cmd)?;
+        }
+        Ok(())
+    }
+
+    // TODO: compaction.
+    //fn compact(&self) -> Result<(), TransactionLogError>;
+    // TODO: force to disk
+    //fn fsync(&self) -> Result<(), TransactionLogError>;
+
+    pub fn read(&self) -> Result<LogIterator, TransactionLogError> {
+        // acquire the lock for the write log to ensure that there are no writes
+        // while we read the log.
+        let write_lock = self.current_log.lock().unwrap();
+
+        let log_filename = current_log_filename(&self.config.storage_basepath);
+        let read_log = OpenOptions::new().read(true).open(&log_filename)?;
+
+        let reader = BufReader::new(read_log);
+
+        // explicitly drop it so that it isn't released early
+        drop(write_lock);
+
+        Ok(LogIterator { reader })
+    }
+
+    fn write_to_log(&self, log: &mut MutexGuard<File>, cmd: &StorageCommand) -> Result<(), TransactionLogError> {
         match cmd {
             StorageCommand::Incr(key) => {
                 log.write_all(b"I")?;
@@ -68,32 +143,7 @@ impl TransactionLog {
             }
             _ => {}
         };
-
         Ok(())
-    }
-
-    // TODO: batch.
-    //fn record_batch(&self, cmd: &[StorageCommand]) -> Result<(), TransactionLogError>;
-    // TODO: compaction.
-    //fn compact(&self) -> Result<(), TransactionLogError>;
-    // TODO: force to disk
-    //fn fsync(&self) -> Result<(), TransactionLogError>;
-
-    pub fn read(&self) -> Result<LogIterator, TransactionLogError> {
-        // acquire the lock for the write log to ensure that there are no writes
-        // while we read the log.
-        let write_lock = self.current_log.lock().unwrap();
-
-        let log_filename = current_log_filename(&self.config.storage_basepath);
-        let read_log = OpenOptions::new().read(true).open(&log_filename)?;
-
-        let reader = BufReader::new(read_log);
-
-        // explicitly drop it so that it isn't released early
-        // TODO: is there a possibility the rust compiler erases this entirely?
-        drop(write_lock);
-
-        Ok(LogIterator { reader })
     }
 }
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,10 +1,10 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Write};
 use std::sync::{Arc, Mutex, MutexGuard};
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 
 use thiserror::Error;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
 use crate::config::Config;
 use crate::storage::StorageCommand;
@@ -30,13 +30,12 @@ pub type TransactionSendQueue = mpsc::Sender<(
     oneshot::Sender<Result<(), TransactionLogError>>,
 )>;
 
-
 impl TransactionWorker {
     pub fn new(recv_queue: TransactionRecvQueue, config: Config) -> Self {
         return TransactionWorker {
             recv_queue,
             log: TransactionLog::new(config).expect("creating transaction log shold not fail"),
-        }
+        };
     }
 
     pub async fn run(&mut self) {
@@ -49,7 +48,10 @@ impl TransactionWorker {
         }
     }
 
-    async fn handle_transaction(&self, cmds: Vec<StorageCommand>) -> Result<(), TransactionLogError> {
+    async fn handle_transaction(
+        &self,
+        cmds: Vec<StorageCommand>,
+    ) -> Result<(), TransactionLogError> {
         self.log.record_batch(&cmds[..])?;
         Ok(())
     }
@@ -113,7 +115,11 @@ impl TransactionLog {
         Ok(LogIterator { reader })
     }
 
-    fn write_to_log(&self, log: &mut MutexGuard<File>, cmd: &StorageCommand) -> Result<(), TransactionLogError> {
+    fn write_to_log(
+        &self,
+        log: &mut MutexGuard<File>,
+        cmd: &StorageCommand,
+    ) -> Result<(), TransactionLogError> {
         match cmd {
             StorageCommand::Incr(key) => {
                 log.write_all(b"I")?;


### PR DESCRIPTION
This completes #6 by separating out the transaction logging behavior into its own worker.