### PR TITLE
Add preliminary support for sets

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -21,6 +21,12 @@ impl From<Blob> for Token {
     }
 }
 
+impl From<&Blob> for Token {
+    fn from(b: &Blob) -> Self {
+        Token::BulkString(Some(b.0.clone()))
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ReadError {
     #[error("not implemented")]

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -15,6 +15,9 @@ pub enum Command {
     Decr(Key),
     Incr(Key),
 
+    SetAdd(Key, Blob),
+    SetMembers(Key),
+
     Unknown(String),
 }
 
@@ -70,6 +73,19 @@ impl Command {
 
                 Ok((Command::Decr(key), length + 1))
             }
+            "SADD" => {
+                validate_length(length, SADD_LENGTH)?;
+                let key = string_token_as_bytes(tokens.get(2))?;
+                let value = string_token_as_bytes(tokens.get(3))?;
+
+                Ok((Command::SetAdd(key, value), length + 1))
+            }
+            "SMEMBERS" => {
+                validate_length(length, SMEMBERS_LENGTH)?;
+                let key = string_token_as_bytes(tokens.get(2))?;
+
+                Ok((Command::SetMembers(key), length + 1))
+            }
             unk => Ok((Command::Unknown(unk.to_string()), length + 1)),
         }
     }
@@ -81,6 +97,8 @@ const GET_LENGTH: usize = 2;
 const SET_LENGTH: usize = 3;
 const INCR_LENGTH: usize = 2;
 const DECR_LENGTH: usize = 2;
+const SADD_LENGTH: usize = 3;
+const SMEMBERS_LENGTH: usize = 2;
 
 fn get_command(tokens: &[Token]) -> Result<(usize, String), CommandError> {
     let length = match tokens.get(0) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub storage_basepath: String,
 
     // Reconstruct the database from the log
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = true)]
     pub read_log: bool,
 
     // Size channel for sending transactions to the transaction worker

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-//use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Error, Formatter};
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -15,8 +15,8 @@ pub type Key = Blob;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Value {
     Blob(Blob),
-    //Set(HashSet<Blob>),
-    //Hash(HashMap<Blob,Blob>),
+    Set(HashSet<Blob>),
+    Hash(HashMap<Blob, Blob>),
     Int(i64),
 }
 


### PR DESCRIPTION
This introduces Set and Hash types in the memory storage and support for basic set operations. Principally, it adds the Redis commands SADD and SMEMBERS.

This starts on #10 , although a few more operations would be nice to implement before considering it "complete".