### PR TITLE
Integrate tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ thiserror = "1.0.35"
 log = "0.4.17"
 env_logger = "0.9.1"
 
+# sometimes we want to trace
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "std"] }
+
 # starting this out async
 # - enable "full" to get all the things, TODO slim this down later!
 # - enable "tracing" to support use of tokio-console

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ atoi = "1.0.0"
 # error tracking is cool
 thiserror = "1.0.35"
 
-# i like loggers, i hate lagers
-log = "0.4.17"
-env_logger = "0.9.1"
-
 # sometimes we want to trace
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "std"] }

--- a/src/connection/conn.rs
+++ b/src/connection/conn.rs
@@ -29,7 +29,7 @@ impl Connection {
     }
 
     pub async fn handle(&mut self) -> std::io::Result<()> {
-        log::info!("(id={}) accepting connection from {}", self.id, self.addr);
+        tracing::debug!("(id={}) accepting connection from {}", self.id, self.addr);
 
         let mut buffer = BytesMut::with_capacity(4 * 1024);
         let cp = CommandProcessor::new(self.context.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
 use anode_kv::config::Config;
 use anode_kv::server::Server;
 use clap::Parser;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::EnvFilter;
 
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_span_events(FmtSpan::ACTIVE)
+        .init();
+
     let config: Config = Config::parse();
-    println!("args: {:?}", config);
+    tracing::info!(config=?config, "Starting server");
 
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(config.worker_threads)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -78,7 +78,7 @@ impl Server {
                         .await;
                 }
                 Err(e) => {
-                    log::error!("error accepting connection: {}", e);
+                    tracing::error!(e=?e, "error accepting connection");
                 }
             }
         }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -43,7 +43,7 @@ impl TransactionWorker {
             let response = self.handle_transaction(cmds).await;
 
             if tx.send(response).is_err() {
-                log::debug!("could not return value to requester; presuming they did not want a value returned");
+                tracing::debug!("could not return value to requester; presuming they did not want a value returned");
             }
         }
     }
@@ -114,6 +114,7 @@ impl TransactionLog {
         Ok(LogIterator { reader })
     }
 
+    #[tracing::instrument(skip(self, log), level = "trace")]
     fn write_to_log(
         &self,
         log: &mut MutexGuard<File>,


### PR DESCRIPTION
This replaces log with tracing, including a formatter that prints to the console. A few spans are added at various levels to allow tracing and inspection of timing, while leaving some info lines.